### PR TITLE
buttonmap.xml not loaded due to typo

### DIFF
--- a/game.libretro.nx/resources/buttonmap.xml
+++ b/game.libretro.nx/resources/buttonmap.xml
@@ -19,6 +19,6 @@
     <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
     <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
     <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
-    <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEF"/>
+    <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
   </controller>
 </buttonmap>


### PR DESCRIPTION
Fixed a typo in the buttonmap that seems to cause the entire buttonmap to fail loading.

I noticed this when I tried to modify the buttonmap and noticed that none of my changes were being recognized. However, I could still move left using the left button on my controller, even with the typo in the buttonmap. So instead of just that one button being broken in the buttonmap it seems that the entire buttonmap is ignored. Some kind of fallback may instead be used for the controller (perhaps hardcoded somewhere) that seems to match the default configuration of this buttonmap. But fixing the typo here gets the buttonmap detected correctly along with any modifications made. 